### PR TITLE
Allow viewClass override

### DIFF
--- a/src/Controller/Component/AjaxComponent.php
+++ b/src/Controller/Component/AjaxComponent.php
@@ -32,6 +32,7 @@ class AjaxComponent extends Component {
 	public $respondAsAjax = false;
 
 	protected $_defaultConfig = array(
+		'viewClass' => 'Ajax.Ajax',
 		'autoDetect' => true,
 		'resolveRedirect' => true,
 		'flashKey' => 'Flash.flash' // Use "messages" for Tools plugin Flash component, set to false to disable
@@ -79,7 +80,7 @@ class AjaxComponent extends Component {
 	 * @return void
 	 */
 	protected function _respondAsAjax() {
-		$this->Controller->viewClass = 'Ajax.Ajax';
+		$this->Controller->viewClass = $this->_config['viewClass'];
 
 		// Set flash messages to the view
 		if ($this->_config['flashKey']) {


### PR DESCRIPTION
Allows viewClass override, doing it this way allows one to extend AjaxView to load application specific helpers for example:

Configure viewClass for this plugin, this code goes to your controller:
```php
// Plugin would use Ajax.Ajax viewClass by default
// Setting it to plain Ajax allows using app specific AjaxView
$this->loadComponent('Ajax.Ajax',[
	'viewClass' => 'Ajax'
]);
```

Extend plugin view to implement your own stuff, namespace tells you where to put this file:
```php
namespace App\View;
use Ajax\View\AjaxView as PluginAjaxView;
class AjaxView extends PluginAjaxView {
    // Load your custom stuff here
}
```