### PR TITLE
Re-organized and arranged the render and _serialize methods in order to fix a bug that occured when _serialize is set to true.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-tactile

--- a/src/Controller/Component/AjaxComponent.php
+++ b/src/Controller/Component/AjaxComponent.php
@@ -133,6 +133,16 @@ class AjaxComponent extends Component {
 		}
 		$this->Controller->set('_serialize', $serializeKeys);
 		$event->stopPropagation();
+	/**
+	 * Checks to see if the Controller->viewVar labeled _serialize is set to boolean true.
+	 *
+	 * @return bool
+	 */
+	protected function _isControllerSerializeTrue() {
+		if (!empty($this->Controller->viewVars['_serialize']) && $this->Controller->viewVars['_serialize'] === true) {
+			return true;
+		}
+		return false;
 	}
 
 }

--- a/src/Controller/Component/AjaxComponent.php
+++ b/src/Controller/Component/AjaxComponent.php
@@ -95,7 +95,7 @@ class AjaxComponent extends Component {
 		}
 
 		// If _serialize is true, *all* viewVars will be serialized; no need to add _message.
-		if (!empty($this->Controller->viewVars['_serialize']) && $this->Controller->viewVars['_serialize'] === true) {
+		if ($this->_isControllerSerializeTrue()) {
 			return;
 		}
 
@@ -127,12 +127,20 @@ class AjaxComponent extends Component {
 
 		$this->Controller->autoRender = true;
 		$this->Controller->set('_redirect', compact('url', 'status'));
+
+		$event->stopPropagation();
+
+		if ($this->_isControllerSerializeTrue()) {
+			return;
+		}
+
 		$serializeKeys = ['_redirect'];
 		if (!empty($this->Controller->viewVars['_serialize'])) {
-			$serializeKeys = array_merge($serializeKeys, $this->Controller->viewVars['_serialize']);
+			$serializeKeys = array_merge($serializeKeys, (array)$this->Controller->viewVars['_serialize']);
 		}
 		$this->Controller->set('_serialize', $serializeKeys);
-		$event->stopPropagation();
+	}
+
 	/**
 	 * Checks to see if the Controller->viewVar labeled _serialize is set to boolean true.
 	 *

--- a/src/Controller/Component/AjaxComponent.php
+++ b/src/Controller/Component/AjaxComponent.php
@@ -101,7 +101,7 @@ class AjaxComponent extends Component {
 
 		$serializeKeys = ['_message'];
 		if (!empty($this->Controller->viewVars['_serialize'])) {
-			$serializeKeys = array_merge($serializeKeys, $this->Controller->viewVars['_serialize']);
+			$serializeKeys = array_merge($serializeKeys, (array)$this->Controller->viewVars['_serialize']);
 		}
 		$this->Controller->set('_serialize', $serializeKeys);
 	}

--- a/src/View/AjaxView.php
+++ b/src/View/AjaxView.php
@@ -45,6 +45,13 @@ class AjaxView extends View {
 	 */
 	public $layout = false;
 
+    /**
+     * List of special view vars.
+     *
+     * @var array
+     */
+    protected $_specialVars = ['_serialize', '_jsonOptions', '_jsonp'];
+
 	/**
 	 * Constructor
 	 *

--- a/src/View/AjaxView.php
+++ b/src/View/AjaxView.php
@@ -156,8 +156,7 @@ class AjaxView extends View {
 				$additionalData[$alias] = $this->viewVars[$key];
 			}
 		}
-
-		return $additionalData ?: null;
+		return $additionalData;
 	}
 
 }

--- a/src/View/AjaxView.php
+++ b/src/View/AjaxView.php
@@ -145,11 +145,6 @@ class AjaxView extends View {
 				$this->viewVars,
 				array_flip($this->_specialVars)
 			);
-
-			if (empty($data)) {
-				return null;
-			}
-
 			return $data;
 		}
 

--- a/src/View/AjaxView.php
+++ b/src/View/AjaxView.php
@@ -139,7 +139,7 @@ class AjaxView extends View {
 	 *   render method.
 	 * @return mixed The data to serialize.
 	 */
-	protected function _dataToSerialize($serialize = true, $additionalData = []) {
+	protected function _dataToSerialize($serialize, $additionalData = []) {
 		if ($serialize === true) {
 			$data = array_diff_key(
 				$this->viewVars,

--- a/src/View/AjaxView.php
+++ b/src/View/AjaxView.php
@@ -4,6 +4,7 @@ namespace Ajax\View;
 use Cake\Event\EventManager;
 use Cake\Network\Request;
 use Cake\Network\Response;
+use Cake\Utility\Hash;
 use Cake\View\View;
 
 /**
@@ -45,12 +46,12 @@ class AjaxView extends View {
 	 */
 	public $layout = false;
 
-    /**
-     * List of special view vars.
-     *
-     * @var array
-     */
-    protected $_specialVars = ['_serialize', '_jsonOptions', '_jsonp'];
+	/**
+	 * List of special view vars.
+	 *
+	 * @var array
+	 */
+	protected $_specialVars = ['_serialize', '_jsonOptions', '_jsonp'];
 
 	/**
 	 * Constructor
@@ -92,7 +93,6 @@ class AjaxView extends View {
 	 * @return string The rendered view.
 	 */
 	public function render($view = null, $layout = null) {
-
 		$dataToSerialize = [
 			'error' => null,
 			'content' => null,
@@ -106,7 +106,7 @@ class AjaxView extends View {
 			$dataToSerialize['content'] = parent::render($view, $layout);
 		}
 
-		$this->viewVars = \Cake\Utility\Hash::merge($this->viewVars, $dataToSerialize);
+		$this->viewVars = Hash::merge($this->viewVars, $dataToSerialize);
 
 		if (isset($this->viewVars['_serialize'])) {
 			$dataToSerialize = $this->_dataToSerialize($this->viewVars['_serialize'], $dataToSerialize);
@@ -119,7 +119,7 @@ class AjaxView extends View {
 	 * Serialize(json_encode) accumulated data from both our custom render method
 	 *   and viewVars set by the user.
 	 *
-	 * @param array Array of data that is to be serialzed.
+	 * @param array $dataToSerialize Array of data that is to be serialzed.
 	 * @return array The serialized data.
 	 */
 	protected function _serialize($dataToSerialize = []) {
@@ -130,43 +130,43 @@ class AjaxView extends View {
 		return $result;
 	}
 
-    /**
-     * Returns data to be serialized based on the value of viewVars.
-     *
-     * @param array|string|bool $serialize The name(s) of the view variable(s) that
-     *   need(s) to be serialized. If true all available view variables will be used.
+	/**
+	 * Returns data to be serialized based on the value of viewVars.
+	 *
+	 * @param array|string|bool $serialize The name(s) of the view variable(s) that
+	 *   need(s) to be serialized. If true all available view variables will be used.
 	 * @param array $additionalData Data items that were defined internally in our own
 	 *   render method.
-     * @return mixed The data to serialize.
-     */
-    protected function _dataToSerialize($serialize = true, $additionalData = []) {
-        if ($serialize === true) {
-            $data = array_diff_key(
-                $this->viewVars,
-                array_flip($this->_specialVars)
-            );
+	 * @return mixed The data to serialize.
+	 */
+	protected function _dataToSerialize($serialize = true, $additionalData = []) {
+		if ($serialize === true) {
+			$data = array_diff_key(
+				$this->viewVars,
+				array_flip($this->_specialVars)
+			);
 
-            if (empty($data)) {
-                return null;
-            }
+			if (empty($data)) {
+				return null;
+			}
 
-            return $data;
-        }
+			return $data;
+		}
 
-        if (is_array($serialize)) {
-            foreach ($serialize as $alias => $key) {
-                if (is_numeric($alias)) {
-                    $alias = $key;
-                }
-                if (array_key_exists($key, $this->viewVars)) {
-                    $additionalData[$alias] = $this->viewVars[$key];
-                }
-            }
+		if (is_array($serialize)) {
+			foreach ($serialize as $alias => $key) {
+				if (is_numeric($alias)) {
+					$alias = $key;
+				}
+				if (array_key_exists($key, $this->viewVars)) {
+					$additionalData[$alias] = $this->viewVars[$key];
+				}
+			}
 
-            return !empty($additionalData) ? $additionalData : null;
-        }
+			return !empty($additionalData) ? $additionalData : null;
+		}
 
-        return isset($this->viewVars[$serialize]) ? $this->viewVars[$serialize] : null;
-    }
+		return isset($this->viewVars[$serialize]) ? $this->viewVars[$serialize] : null;
+	}
 
 }

--- a/src/View/AjaxView.php
+++ b/src/View/AjaxView.php
@@ -153,20 +153,16 @@ class AjaxView extends View {
 			return $data;
 		}
 
-		if (is_array($serialize)) {
-			foreach ($serialize as $alias => $key) {
-				if (is_numeric($alias)) {
-					$alias = $key;
-				}
-				if (array_key_exists($key, $this->viewVars)) {
-					$additionalData[$alias] = $this->viewVars[$key];
-				}
+		foreach ((array)$serialize as $alias => $key) {
+			if (is_numeric($alias)) {
+				$alias = $key;
 			}
-
-			return !empty($additionalData) ? $additionalData : null;
+			if (array_key_exists($key, $this->viewVars)) {
+				$additionalData[$alias] = $this->viewVars[$key];
+			}
 		}
 
-		return isset($this->viewVars[$serialize]) ? $this->viewVars[$serialize] : null;
+		return !empty($additionalData) ? $additionalData : null;
 	}
 
 }

--- a/src/View/AjaxView.php
+++ b/src/View/AjaxView.php
@@ -106,7 +106,7 @@ class AjaxView extends View {
 			$dataToSerialize['content'] = parent::render($view, $layout);
 		}
 
-		$this->viewVars = Hash::merge($this->viewVars, $dataToSerialize);
+		$this->viewVars = Hash::merge($dataToSerialize, $this->viewVars);
 
 		if (isset($this->viewVars['_serialize'])) {
 			$dataToSerialize = $this->_dataToSerialize($this->viewVars['_serialize'], $dataToSerialize);

--- a/src/View/AjaxView.php
+++ b/src/View/AjaxView.php
@@ -162,7 +162,7 @@ class AjaxView extends View {
 			}
 		}
 
-		return !empty($additionalData) ? $additionalData : null;
+		return $additionalData ?: null;
 	}
 
 }

--- a/src/View/AjaxView.php
+++ b/src/View/AjaxView.php
@@ -92,7 +92,8 @@ class AjaxView extends View {
 	 * @return string The rendered view.
 	 */
 	public function render($view = null, $layout = null) {
-		$response = [
+
+		$dataToSerialize = [
 			'error' => null,
 			'content' => null,
 		];
@@ -102,39 +103,70 @@ class AjaxView extends View {
 		}
 
 		if ($view !== false && !isset($this->viewVars['_redirect']) && $this->_getViewFileName($view)) {
-			$response['content'] = parent::render($view, $layout);
+			$dataToSerialize['content'] = parent::render($view, $layout);
 		}
+
+		$this->viewVars = \Cake\Utility\Hash::merge($this->viewVars, $dataToSerialize);
+
 		if (isset($this->viewVars['_serialize'])) {
-			$response = $this->_serialize($response, $this->viewVars['_serialize']);
+			$dataToSerialize = $this->_dataToSerialize($this->viewVars['_serialize'], $dataToSerialize);
 		}
-		$result = json_encode($response);
+
+		return $this->_serialize($dataToSerialize);
+	}
+
+	/**
+	 * Serialize(json_encode) accumulated data from both our custom render method
+	 *   and viewVars set by the user.
+	 *
+	 * @param array Array of data that is to be serialzed.
+	 * @return array The serialized data.
+	 */
+	protected function _serialize($dataToSerialize = []) {
+		$result = json_encode($dataToSerialize);
 		if (json_last_error() !== JSON_ERROR_NONE) {
 			return json_encode(['error' => json_last_error_msg()]);
 		}
 		return $result;
 	}
 
-	/**
-	 * Serializes view vars.
-	 *
-	 * @param array $response Response data array.
-	 * @param array $serialize The viewVars that need to be serialized.
-	 * @return array The serialized data.
-	 */
-	protected function _serialize($response, $serialize) {
-		if (is_array($serialize)) {
-			foreach ($serialize as $alias => $key) {
-				if (is_numeric($alias)) {
-					$alias = $key;
-				}
-				if (array_key_exists($key, $this->viewVars)) {
-					$response[$alias] = $this->viewVars[$key];
-				}
-			}
-		} else {
-			$response[$serialize] = isset($this->viewVars[$serialize]) ? $this->viewVars[$serialize] : null;
-		}
-		return $response;
-	}
+    /**
+     * Returns data to be serialized based on the value of viewVars.
+     *
+     * @param array|string|bool $serialize The name(s) of the view variable(s) that
+     *   need(s) to be serialized. If true all available view variables will be used.
+	 * @param array $additionalData Data items that were defined internally in our own
+	 *   render method.
+     * @return mixed The data to serialize.
+     */
+    protected function _dataToSerialize($serialize = true, $additionalData = []) {
+        if ($serialize === true) {
+            $data = array_diff_key(
+                $this->viewVars,
+                array_flip($this->_specialVars)
+            );
+
+            if (empty($data)) {
+                return null;
+            }
+
+            return $data;
+        }
+
+        if (is_array($serialize)) {
+            foreach ($serialize as $alias => $key) {
+                if (is_numeric($alias)) {
+                    $alias = $key;
+                }
+                if (array_key_exists($key, $this->viewVars)) {
+                    $additionalData[$alias] = $this->viewVars[$key];
+                }
+            }
+
+            return !empty($additionalData) ? $additionalData : null;
+        }
+
+        return isset($this->viewVars[$serialize]) ? $this->viewVars[$serialize] : null;
+    }
 
 }

--- a/tests/TestCase/View/AjaxViewTest.php
+++ b/tests/TestCase/View/AjaxViewTest.php
@@ -87,6 +87,32 @@ class AjaxViewTest extends TestCase {
 	}
 
 	/**
+	 * AjaxViewTest::testSerializeSetTrue()
+	 *
+	 * Test the case where the _serialize viewVar is set to true signaling that all viewVars
+	 *   should be serialized.
+	 *
+	 * @return void
+	 */
+	public function testSerializeSetTrue() {
+		$Request = new Request();
+		$Response = new Response();
+		$items = [
+			['title' => 'Title One', 'link' => 'http://example.org/one', 'author' => 'one@example.org', 'description' => 'Content one'],
+			['title' => 'Title Two', 'link' => 'http://example.org/two', 'author' => 'two@example.org', 'description' => 'Content two'],
+		];
+		$multiple = 'items';
+		$View = new AjaxView($Request, $Response);
+		$View->set(['items' => $items, 'multiple' => $multiple, '_serialize' => true]);
+		$result = $View->render(false);
+
+		$this->assertSame('application/json', $Response->type());
+		$expected = ['error' => null, 'content' => null, 'items' => $items, 'multiple' => $multiple];
+		$expected = json_encode($expected);
+		$this->assertTextEquals($expected, $result);
+	}
+
+	/**
 	 * AjaxViewTest::testError()
 	 *
 	 * @return void


### PR DESCRIPTION
When _serialize was set to true in order to automatically serialize all viewVars the resulting ajax response was always _{"error":null,"content":"","1":null}_ where _serialize was set to 1 with a null value. I re-organized the code to what made a little more sense to myself as well as resolved the error.