### PR TITLE
Change AjaxWiew to avoid render ajax view when data is serialized

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
 	},
 	"require-dev":{
 		"dereuromark/cakephp-tools": "^1.4",
-		"fig-r/psr2r-sniffer": "dev-master"
+		"fig-r/psr2r-sniffer": "dev-master",
+		"phpunit/phpunit": "^5.7.14"
 	},
 	"autoload": {
 		"psr-4": {

--- a/src/View/AjaxView.php
+++ b/src/View/AjaxView.php
@@ -98,6 +98,10 @@ class AjaxView extends View {
 			'content' => null,
 		];
 
+		if (isset($this->viewVars['_serialize'])) {
+			$view = false;
+		}
+
 		if (!empty($this->viewVars['error'])) {
 			$view = false;
 		}

--- a/tests/TestCase/View/AjaxViewTest.php
+++ b/tests/TestCase/View/AjaxViewTest.php
@@ -70,7 +70,7 @@ class AjaxViewTest extends TestCase {
 	 */
 	public function testRenderWithSerialize() {
 		$Request = new Request();
-		$Response = new Responses);
+		$Response = new Response();
 		$items = [
 			['title' => 'Title One', 'link' => 'http://example.org/one', 'author' => 'one@example.org', 'description' => 'Content one'],
 			['title' => 'Title Two', 'link' => 'http://example.org/two', 'author' => 'two@example.org', 'description' => 'Content two'],

--- a/tests/TestCase/View/AjaxViewTest.php
+++ b/tests/TestCase/View/AjaxViewTest.php
@@ -70,18 +70,17 @@ class AjaxViewTest extends TestCase {
 	 */
 	public function testRenderWithSerialize() {
 		$Request = new Request();
-		$Response = new Response();
+		$Response = new Responses);
 		$items = [
 			['title' => 'Title One', 'link' => 'http://example.org/one', 'author' => 'one@example.org', 'description' => 'Content one'],
 			['title' => 'Title Two', 'link' => 'http://example.org/two', 'author' => 'two@example.org', 'description' => 'Content two'],
 		];
 		$View = new AjaxView($Request, $Response);
 		$View->set(['items' => $items, '_serialize' => 'items']);
-		$View->viewPath = 'Items';
-		$result = $View->render('index');
+		$result = $View->render(false);
 
 		$this->assertSame('application/json', $Response->type());
-		$expected = ['error' => null, 'content' => 'My Index Test ctp', 'items' => $items];
+		$expected = ['error' => null, 'content' => null, 'items' => $items];
 		$expected = json_encode($expected);
 		$this->assertTextEquals($expected, $result);
 	}


### PR DESCRIPTION
I change The AjaxView to avoid render a View when there is data serialized.
I change the Test to check it that out.

Right now, when data are serialized there is no one Item/ajax.view called and content key of the json returned is at null.