### PR TITLE
Change AjaxView to avoid it rendering execption when view do not exist

### DIFF
--- a/src/View/AjaxView.php
+++ b/src/View/AjaxView.php
@@ -159,4 +159,35 @@ class AjaxView extends View {
 		return $additionalData;
 	}
 
+	/**
+	 * This is an overriding of _getViewFileName() from View class which is throwing MissingTemplateException when filename do not exist
+     * Returns filename of given action's template file (.ctp) as a string.
+     * CamelCased action names will be under_scored by default.
+     * This means that you can have LongActionNames that refer to
+     * long_action_names.ctp views. You can change the inflection rule by
+     * overriding _inflectViewFileName.
+     *
+     * @param string|null $name Controller action to find template filename for
+     * @return string|null Template filename or null if template filename do not exist
+     */
+    protected function _getViewFileName($name = null)
+    {
+        $templatePath = $this->templatePath . DIRECTORY_SEPARATOR;
+        $subDir = $this->subDir . DIRECTORY_SEPARATOR;
+
+        list($plugin, $name) = $this->pluginSplit($name);
+        $name = str_replace('/', DIRECTORY_SEPARATOR, $name);
+
+        if (strpos($name, DIRECTORY_SEPARATOR) === false && $name !== '' && $name[0] !== '.') {
+            $name = $templatePath . $subDir . $this->_inflectViewFileName($name);
+        }
+
+        foreach ($this->_paths($plugin) as $path) {
+            if (file_exists($path . $name . $this->_ext)) {
+                return $this->_checkFilePath($path . $name . $this->_ext, $path);
+            }
+        }
+        return null;
+    }
+
 }

--- a/tests/TestCase/View/AjaxViewTest.php
+++ b/tests/TestCase/View/AjaxViewTest.php
@@ -85,6 +85,7 @@ class AjaxViewTest extends TestCase {
 		$expected = json_encode($expected);
 		$this->assertTextEquals($expected, $result);
 	}
+	
 
 	/**
 	 * AjaxViewTest::testSerializeSetTrue()
@@ -170,6 +171,26 @@ class AjaxViewTest extends TestCase {
 
 		$this->assertSame('application/json', $Response->type());
 		$expected = ['error' => null, 'content' => 'My Index Test ctp'];
+		$expected = json_encode($expected);
+		$this->assertTextEquals($expected, $result);
+	}
+
+	/**
+	 * AjaxViewTest::testRenderAViewThatDoNotExist()
+	 *
+	 * Test the case where a view do not exist for action
+	 *
+	 * @return void
+	 */
+	public function testRenderAViewThatDoNotExist() {
+		$Request = new Request();
+		$Response = new Response();
+		$View = new AjaxView($Request, $Response);
+		$View->viewPath = 'Items';
+		$result = $View->render('no_existing_view');
+
+		$this->assertSame('application/json', $Response->type());
+		$expected = ['error' => null, 'content' => null];
 		$expected = json_encode($expected);
 		$this->assertTextEquals($expected, $result);
 	}


### PR DESCRIPTION
I changed The AjaxView to avoid render a View when there is data serialized.
I changed the Test to check it that out.

Right now, when data are serialized there is no one Item/ajax.view called and content key of the json returned is at null.

