### PR TITLE
Make AjaxView extend AppView

### DIFF
--- a/docs/View/Ajax.md
+++ b/docs/View/Ajax.md
@@ -62,11 +62,10 @@ public function statesAjax() {
 ```
 
 ## Custom Plugin helpers
-If your view classes need plugin helpers, and you are not using the controller way anymore to load/define helpers, then you might need to extend the view class to project level and add them there:
+If your view classes needs additional plugin helpers, and you are not using the controller way anymore to load/define helpers, then you might need to extend the view class to project level and add them there:
 ```php
 namespace App\View;
 
-use Cake\View\View;
 use Ajax\View\AjaxView as PluginAjaxView;
 
 class AjaxView extends PluginAjaxView {
@@ -75,6 +74,7 @@ class AjaxView extends PluginAjaxView {
      * @return void
      */
     public function initialize() {
+        parent::initialize();
         $this->loadHelper('...);
         ...
     }
@@ -82,7 +82,7 @@ class AjaxView extends PluginAjaxView {
 }
 ```
 Then make sure you load the app `Ajax` view class instead of the `Ajax.Ajax` one.
-If you are using the component, you can set Configure key `'Ajax.viewClass'` to your `App\View\AjaxView` here.
+If you are using the component, you can set Configure key `'Ajax.viewClass'` to your `'Ajax'` here.
 
 ## Tips
 I found the following quite useful for your jQuery AJAX code as some browsers might not properly work without it (at least for me it used to).

--- a/src/View/AjaxView.php
+++ b/src/View/AjaxView.php
@@ -1,11 +1,11 @@
 <?php
 namespace Ajax\View;
 
+use App\View\AppView;
 use Cake\Event\EventManager;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\Utility\Hash;
-use Cake\View\View;
 
 /**
  * A view to handle AJAX requests.
@@ -20,7 +20,7 @@ use Cake\View\View;
  * @author Mark Scherer
  * @license http://opensource.org/licenses/mit-license.php MIT
  */
-class AjaxView extends View {
+class AjaxView extends AppView {
 
 	const JSON_OPTIONS = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT | JSON_PARTIAL_OUTPUT_ON_ERROR;
 

--- a/tests/TestApp/src/View/AppView.php
+++ b/tests/TestApp/src/View/AppView.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace TestApp\View;
+
+use Cake\View\View;
+
+class AppView extends View {
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -64,6 +64,8 @@ Cake\Core\Configure::write('App.paths', [
 
 Cake\Core\Plugin::load('Ajax', ['path' => ROOT . DS, 'bootstrap' => true]);
 
+class_alias(\TestApp\View\AppView::class, 'App\View\AppView');
+
 // Ensure default test connection is defined
 if (!getenv('db_class')) {
 	putenv('db_class=Cake\Database\Driver\Sqlite');


### PR DESCRIPTION
Resolves https://github.com/dereuromark/cakephp-ajax/issues/33

All cake apps by now should have an AppView class present 
As such, this should be able to go out as minor.

This way the AjaxView automatically shares the AppView helpers loaded.