### PR TITLE
Swap "_serialize" with new "serialize" key

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
 		"test": "vendor/bin/phpunit",
 		"test-coverage": "vendor/bin/phpunit --log-junit tmp/coverage/unitreport.xml --coverage-html tmp/coverage --coverage-clover tmp/coverage/coverage.xml",
 		"stan": "phpstan analyse",
-		"stan-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:^1.0.0 && mv composer.backup composer.json",
+		"test-setup": "cp composer.json composer.backup && composer require --dev phpstan/phpstan:^1.0.0 && mv composer.backup composer.json",
 		"cs-check": "phpcs --extensions=php",
 		"cs-fix": "phpcbf --extensions=php"
 	},

--- a/docs/Component/Ajax.md
+++ b/docs/Component/Ajax.md
@@ -63,12 +63,12 @@ are not reserved:
 ```php
 $content = ['id' => 1, 'title' => 'title'];
 $this->set(compact('content'));
-$this->set('_serialize', ['content']);
+$this->set('serialize', ['content']);
 ```
 results in
 
     "content":{...}, ...
-    
+
 ### AJAX Delete
 
 For usability reasons you might want to delete a row in a paginated table, without the need to refresh the whole page.

--- a/docs/View/Ajax.md
+++ b/docs/View/Ajax.md
@@ -42,7 +42,7 @@ The result can be this, for example:
     "error": ''
 }
 ```
-You can add more data to the response object via `_serialize`.
+You can add more data to the response object via `serialize`.
 
 
 ### Drop down selections

--- a/src/Controller/Component/AjaxComponent.php
+++ b/src/Controller/Component/AjaxComponent.php
@@ -87,16 +87,16 @@ class AjaxComponent extends Component {
 			$this->getController()->set('_message', $message);
 		}
 
-		// If _serialize is true, *all* viewVars will be serialized; no need to add _message.
+		// If serialize is true, *all* viewVars will be serialized; no need to add _message.
 		if ($this->_isControllerSerializeTrue()) {
 			return;
 		}
 
 		$serializeKeys = ['_message'];
-		if (!empty($this->getController()->viewBuilder()->getVar('_serialize'))) {
-			$serializeKeys = array_merge($serializeKeys, (array)$this->getController()->viewBuilder()->getVar('_serialize'));
+		if (!empty($this->getController()->viewBuilder()->getVar('serialize'))) {
+			$serializeKeys = array_merge($serializeKeys, (array)$this->getController()->viewBuilder()->getVar('serialize'));
 		}
-		$this->getController()->set('_serialize', $serializeKeys);
+		$this->getController()->set('serialize', $serializeKeys);
 	}
 
 	/**
@@ -129,10 +129,10 @@ class AjaxComponent extends Component {
 		}
 
 		$serializeKeys = ['_redirect'];
-		if ($this->getController()->viewBuilder()->getVar('_serialize')) {
-			$serializeKeys = array_merge($serializeKeys, (array)$this->getController()->viewBuilder()->getVar('_serialize'));
+		if ($this->getController()->viewBuilder()->getVar('serialize')) {
+			$serializeKeys = array_merge($serializeKeys, (array)$this->getController()->viewBuilder()->getVar('serialize'));
 		}
-		$this->getController()->set('_serialize', $serializeKeys);
+		$this->getController()->set('serialize', $serializeKeys);
 		// Further changes will be required here when the change to immutable response objects is completed
 		$response = $this->getController()->render();
 
@@ -140,12 +140,12 @@ class AjaxComponent extends Component {
 	}
 
 	/**
-	 * Checks to see if the Controller->viewVar labeled _serialize is set to boolean true.
+	 * Checks to see if the Controller->viewVar labeled serialize is set to boolean true.
 	 *
 	 * @return bool
 	 */
 	protected function _isControllerSerializeTrue() {
-		if ($this->getController()->viewBuilder()->getVar('_serialize') === true) {
+		if ($this->getController()->viewBuilder()->getVar('serialize') === true) {
 			return true;
 		}
 

--- a/src/View/AjaxView.php
+++ b/src/View/AjaxView.php
@@ -16,7 +16,7 @@ use Cake\Utility\Hash;
  * A response to an invalid request may be just HTTP status "code" and error "message"
  * (e.g, on 4xx or 5xx).
  * A response to a valid request will always contain at least "content" and "error" keys.
- * You can add more data using _serialize.
+ * You can add more data using serialize.
  *
  * @author Mark Scherer
  * @license http://opensource.org/licenses/mit-license.php MIT
@@ -47,7 +47,7 @@ class AjaxView extends AppView {
 	 *
 	 * @var array<string>
 	 */
-	protected $_specialVars = ['_serialize', '_jsonOptions', '_jsonp'];
+	protected $_specialVars = ['serialize', '_jsonOptions', '_jsonp'];
 
 	/**
 	 * Constructor
@@ -119,8 +119,8 @@ class AjaxView extends AppView {
 		}
 
 		$this->viewVars = Hash::merge($dataToSerialize, $this->viewVars);
-		if (isset($this->viewVars['_serialize'])) {
-			$dataToSerialize = $this->_dataToSerialize($this->viewVars['_serialize'], $dataToSerialize);
+		if (isset($this->viewVars['serialize'])) {
+			$dataToSerialize = $this->_dataToSerialize($this->viewVars['serialize'], $dataToSerialize);
 		}
 
 		return $this->_serialize($dataToSerialize);

--- a/tests/TestCase/Controller/Component/AjaxComponentTest.php
+++ b/tests/TestCase/Controller/Component/AjaxComponentTest.php
@@ -170,12 +170,12 @@ class AjaxComponentTest extends TestCase {
 
 		$content = ['id' => 1, 'title' => 'title'];
 		$this->Controller->set(compact('content'));
-		$this->Controller->set('_serialize', ['content']);
+		$this->Controller->set('serialize', ['content']);
 
 		$this->Controller->components()->load('Ajax.Ajax');
 		$this->assertNotEmpty($this->Controller->viewBuilder()->getVars());
-		$this->assertNotEmpty($this->Controller->viewBuilder()->getVar('_serialize'));
-		$this->assertEquals('content', $this->Controller->viewBuilder()->getVar('_serialize')[0]);
+		$this->assertNotEmpty($this->Controller->viewBuilder()->getVar('serialize'));
+		$this->assertEquals('content', $this->Controller->viewBuilder()->getVar('serialize')[0]);
 	}
 
 	/**
@@ -189,7 +189,7 @@ class AjaxComponentTest extends TestCase {
 
 		$content = ['id' => 1, 'title' => 'title'];
 		$this->Controller->set(compact('content'));
-		$this->Controller->set('_serialize', ['content']);
+		$this->Controller->set('serialize', ['content']);
 
 		// Let's try a permanent redirect
 		$this->Controller->redirect('/', 301);
@@ -211,8 +211,8 @@ class AjaxComponentTest extends TestCase {
 		$this->assertArrayHasKey('_message', $this->Controller->viewBuilder()->getVars());
 
 		$this->assertNotEmpty($this->Controller->viewBuilder()->getVars());
-		$this->assertNotEmpty($this->Controller->viewBuilder()->getVar('_serialize'));
-		$this->assertTrue(in_array('content', $this->Controller->viewBuilder()->getVar('_serialize')));
+		$this->assertNotEmpty($this->Controller->viewBuilder()->getVar('serialize'));
+		$this->assertTrue(in_array('content', $this->Controller->viewBuilder()->getVar('serialize')));
 	}
 
 }

--- a/tests/TestCase/View/AjaxViewTest.php
+++ b/tests/TestCase/View/AjaxViewTest.php
@@ -48,7 +48,7 @@ class AjaxViewTest extends TestCase {
 			['title' => 'Title Two', 'link' => 'http://example.org/two', 'author' => 'two@example.org', 'description' => 'Content two'],
 		];
 		$View = new AjaxView($Request, $Response);
-		$View->set(['items' => $items, '_serialize' => ['items']]);
+		$View->set(['items' => $items, 'serialize' => ['items']]);
 		$result = $View->render('');
 
 		$response = $View->getResponse();
@@ -69,7 +69,7 @@ class AjaxViewTest extends TestCase {
 			['title' => 'Title Two', 'link' => 'http://example.org/two', 'author' => 'two@example.org', 'description' => 'Content two'],
 		];
 		$View = new AjaxView($Request, $Response);
-		$View->set(['items' => $items, '_serialize' => 'items']);
+		$View->set(['items' => $items, 'serialize' => 'items']);
 		$View->setTemplatePath('Items');
 		$result = $View->render('index');
 
@@ -81,7 +81,7 @@ class AjaxViewTest extends TestCase {
 	}
 
 	/**
-	 * Test the case where the _serialize viewVar is set to true signaling that all viewVars
+	 * Test the case where the serialize viewVar is set to true signaling that all viewVars
 	 *   should be serialized.
 	 *
 	 * @return void
@@ -95,7 +95,7 @@ class AjaxViewTest extends TestCase {
 		];
 		$multiple = 'items';
 		$View = new AjaxView($Request, $Response);
-		$View->set(['items' => $items, 'multiple' => $multiple, '_serialize' => true]);
+		$View->set(['items' => $items, 'multiple' => $multiple, 'serialize' => true]);
 		$result = $View->render('');
 
 		$response = $View->getResponse();
@@ -116,7 +116,7 @@ class AjaxViewTest extends TestCase {
 			['title' => 'Title Two', 'link' => 'http://example.org/two', 'author' => 'two@example.org', 'description' => 'Content two'],
 		];
 		$View = new AjaxView($Request, $Response);
-		$View->set(['error' => 'Some message', 'items' => $items, '_serialize' => ['error', 'items']]);
+		$View->set(['error' => 'Some message', 'items' => $items, 'serialize' => ['error', 'items']]);
 		$View->setTemplatePath('Items');
 		$result = $View->render('index');
 


### PR DESCRIPTION
As per the [CakePHP docs](https://book.cakephp.org/4/en/views/json-and-xml-views.html#using-data-views-with-the-serialize-key), the new reserved view key to serialize variables is now called `serialize`. The old key [has been deprecated since 4.0](https://book.cakephp.org/4/en/appendices/4-0-migration-guide.html#view).

This PR updates the usages of the old key with the new one. It is a **potentially breaking change** for existing users of the project that are using the old key.