### PR TITLE
Changes deprecated '_serialize' key with 'serialize'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 phpunit.phar
-.phpunit.result.cache
+.phpunit.cache
 composer.lock
 vendor/
 plugins/

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 	},
 	"require-dev": {
 		"dereuromark/cakephp-tools": "dev-cake5",
-		"phpunit/phpunit": "^9.5.16",
+		"phpunit/phpunit": "^10.2.1",
 		"fig-r/psr2r-sniffer": "dev-next"
 	},
 	"autoload": {

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,9 @@
 	"require-dev": {
 		"dereuromark/cakephp-tools": "dev-cake5",
 		"phpunit/phpunit": "^10.2.1",
-		"fig-r/psr2r-sniffer": "dev-next"
-	},
+		"fig-r/psr2r-sniffer": "dev-next",
+      "ext-mbstring": "*"
+    },
 	"autoload": {
 		"psr-4": {
 			"Ajax\\": "src/"

--- a/docs/Component/Ajax.md
+++ b/docs/Component/Ajax.md
@@ -57,7 +57,7 @@ are not reserved:
 ```php
 $content = ['id' => 1, 'title' => 'title'];
 $this->set(compact('content'));
-$this->set('_serialize', ['content']);
+$this->set('serialize', ['content']);
 ```
 results in
 

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -17,7 +17,7 @@ There are a few guidelines that I need contributors to follow:
 
 Tip: You can use the composer commands to set up everything:
 * `composer install`
-* `composer test-setup`
+* `composer stan-setup`
 
 Now you can run the tests via `composer test` and get coverage via `composer test-coverage` commands.
 

--- a/docs/View/Ajax.md
+++ b/docs/View/Ajax.md
@@ -42,7 +42,7 @@ The result can be this, for example:
     "error": ''
 }
 ```
-You can add more data to the response object via `_serialize`.
+You can add more data to the response object via `serialize`.
 
 
 ### Drop down selections

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,24 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="tests/bootstrap.php" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 bootstrap="tests/bootstrap.php"
+		 xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.2/phpunit.xsd"
+		 cacheDirectory=".phpunit.cache">
 	<php>
+		<ini name="memory_limit" value="-1"/>
 		<ini name="apc.enable_cli" value="1"/>
-		<!-- E_ALL => 32767 -->
-		<!-- E_ALL & ~E_USER_DEPRECATED => 16383 -->
+		<!-- E_ALL & ~E_USER_DEPRECATED (16383)-->
+		<!-- E_ALL (32767) -->
 		<ini name="error_reporting" value="16383"/>
 	</php>
 	<testsuites>
 		<testsuite name="ajax">
-			<directory>tests/</directory>
+			<directory>tests/TestCase/</directory>
 		</testsuite>
 	</testsuites>
-
 	<extensions>
-			<extension class="\Cake\TestSuite\Fixture\PHPUnitExtension"/>
+		<bootstrap class="\Cake\TestSuite\Fixture\Extension\PHPUnitExtension"/>
 	</extensions>
-
-	<coverage>
+	<source>
 		<include>
 			<directory suffix=".php">src/</directory>
 		</include>
-	</coverage>
+	</source>
 </phpunit>

--- a/src/Controller/Component/AjaxComponent.php
+++ b/src/Controller/Component/AjaxComponent.php
@@ -26,7 +26,7 @@ class AjaxComponent extends Component {
 	/**
 	 * @var bool
 	 */
-	protected $respondAsAjax = false;
+	public bool $respondAsAjax = false;
 
 	/**
 	 * @var array<string, mixed>
@@ -78,7 +78,7 @@ class AjaxComponent extends Component {
 	/**
 	 * @return void
 	 */
-	protected function _respondAsAjax() {
+	protected function _respondAsAjax(): void {
 		$this->getController()->viewBuilder()->setClassName($this->_config['viewClass']);
 
 		// Set flash messages to the view
@@ -144,7 +144,7 @@ class AjaxComponent extends Component {
 	 *
 	 * @return bool
 	 */
-	protected function _isControllerSerializeTrue() {
+	protected function _isControllerSerializeTrue(): bool {
 		if ($this->getController()->viewBuilder()->getVar('serialize') === true) {
 			return true;
 		}
@@ -157,7 +157,7 @@ class AjaxComponent extends Component {
 	 *
 	 * @return bool
 	 */
-	protected function _isActionEnabled() {
+	protected function _isActionEnabled(): bool {
 		$actions = $this->getConfig('actions');
 		if (!$actions) {
 			return true;

--- a/src/Controller/Component/AjaxComponent.php
+++ b/src/Controller/Component/AjaxComponent.php
@@ -87,16 +87,16 @@ class AjaxComponent extends Component {
 			$this->getController()->set('_message', $message);
 		}
 
-		// If _serialize is true, *all* viewVars will be serialized; no need to add _message.
+		// If `serialize` is true, *all* viewVars will be serialized; no need to add _message.
 		if ($this->_isControllerSerializeTrue()) {
 			return;
 		}
 
 		$serializeKeys = ['_message'];
-		if (!empty($this->getController()->viewBuilder()->getVar('_serialize'))) {
-			$serializeKeys = array_merge($serializeKeys, (array)$this->getController()->viewBuilder()->getVar('_serialize'));
+		if (!empty($this->getController()->viewBuilder()->getVar('serialize'))) {
+			$serializeKeys = array_merge($serializeKeys, (array)$this->getController()->viewBuilder()->getVar('serialize'));
 		}
-		$this->getController()->set('_serialize', $serializeKeys);
+		$this->getController()->set('serialize', $serializeKeys);
 	}
 
 	/**
@@ -129,10 +129,10 @@ class AjaxComponent extends Component {
 		}
 
 		$serializeKeys = ['_redirect'];
-		if ($this->getController()->viewBuilder()->getVar('_serialize')) {
-			$serializeKeys = array_merge($serializeKeys, (array)$this->getController()->viewBuilder()->getVar('_serialize'));
+		if ($this->getController()->viewBuilder()->getVar('serialize')) {
+			$serializeKeys = array_merge($serializeKeys, (array)$this->getController()->viewBuilder()->getVar('serialize'));
 		}
-		$this->getController()->set('_serialize', $serializeKeys);
+		$this->getController()->set('serialize', $serializeKeys);
 		// Further changes will be required here when the change to immutable response objects is completed
 		$response = $this->getController()->render();
 
@@ -140,12 +140,12 @@ class AjaxComponent extends Component {
 	}
 
 	/**
-	 * Checks to see if the Controller->viewVar labeled _serialize is set to boolean true.
+	 * Checks to see if the Controller->viewVar labeled `serialize` is set to boolean true.
 	 *
 	 * @return bool
 	 */
 	protected function _isControllerSerializeTrue() {
-		if ($this->getController()->viewBuilder()->getVar('_serialize') === true) {
+		if ($this->getController()->viewBuilder()->getVar('serialize') === true) {
 			return true;
 		}
 

--- a/src/View/AjaxView.php
+++ b/src/View/AjaxView.php
@@ -16,7 +16,7 @@ use Cake\Utility\Hash;
  * A response to an invalid request may be just HTTP status "code" and error "message"
  * (e.g, on 4xx or 5xx).
  * A response to a valid request will always contain at least "content" and "error" keys.
- * You can add more data using _serialize.
+ * You can add more data using `serialize`.
  *
  * @author Mark Scherer
  * @license http://opensource.org/licenses/mit-license.php MIT
@@ -47,7 +47,7 @@ class AjaxView extends AppView {
 	 *
 	 * @var array<string>
 	 */
-	protected array $_specialVars = ['_serialize', '_jsonOptions', '_jsonp'];
+	protected array $_specialVars = ['serialize', '_jsonOptions', '_jsonp'];
 
 	/**
 	 * Constructor
@@ -119,8 +119,8 @@ class AjaxView extends AppView {
 		}
 
 		$this->viewVars = Hash::merge($dataToSerialize, $this->viewVars);
-		if (isset($this->viewVars['_serialize'])) {
-			$dataToSerialize = $this->_dataToSerialize($this->viewVars['_serialize'], $dataToSerialize);
+		if (isset($this->viewVars['serialize'])) {
+			$dataToSerialize = $this->_dataToSerialize($this->viewVars['serialize'], $dataToSerialize);
 		}
 
 		return $this->_serialize($dataToSerialize);

--- a/src/View/AjaxView.php
+++ b/src/View/AjaxView.php
@@ -83,7 +83,7 @@ class AjaxView extends AppView {
 	/**
 	 * Renders an AJAX view.
 	 * The rendered content will be part of the JSON response object and
-	 * can be accessed via response.content in JavaScript.
+	 * can be accessed via `response.content` in JavaScript.
 	 *
 	 * If an error or success has been set, the rendering will be skipped.
 	 *
@@ -133,20 +133,20 @@ class AjaxView extends AppView {
 	 * @param array<mixed> $dataToSerialize Array of data that is to be serialzed.
 	 * @return string The serialized data.
 	 */
-	protected function _serialize(array $dataToSerialize = []) {
+	protected function _serialize(array $dataToSerialize = []): string {
 		return JsonEncoder::encode($dataToSerialize);
 	}
 
 	/**
 	 * Returns data to be serialized based on the value of viewVars.
 	 *
-	 * @param array<mixed>|string|true $serialize The name(s) of the view variable(s) that
+	 * @param array<mixed>|string|bool $serialize The name(s) of the view variable(s) that
 	 *   need(s) to be serialized. If true all available view variables will be used.
 	 * @param array<mixed> $additionalData Data items that were defined internally in our own
 	 *   render method.
 	 * @return array<mixed> The data to serialize.
 	 */
-	protected function _dataToSerialize($serialize, array $additionalData = []): array {
+	protected function _dataToSerialize(array|bool|string $serialize, array $additionalData = []): array {
 		if ($serialize === true) {
 			$data = array_diff_key(
 				$this->viewVars,

--- a/src/View/JsonEncoder.php
+++ b/src/View/JsonEncoder.php
@@ -14,7 +14,7 @@ class JsonEncoder {
 	 *
 	 * @return string
 	 */
-	public static function encode(array $dataToSerialize, $options = 0) {
+	public static function encode(array $dataToSerialize, int $options = 0): string {
 		$result = json_encode($dataToSerialize, $options);
 
 		$error = null;

--- a/tests/TestApp/src/Controller/AjaxTestController.php
+++ b/tests/TestApp/src/Controller/AjaxTestController.php
@@ -7,6 +7,7 @@ use Cake\Controller\Controller;
 class AjaxTestController extends Controller {
 
 	/**
+	 * @throws \Exception
 	 * @return void
 	 */
 	public function initialize(): void {

--- a/tests/TestCase/Controller/Component/AjaxComponentTest.php
+++ b/tests/TestCase/Controller/Component/AjaxComponentTest.php
@@ -22,7 +22,7 @@ class AjaxComponentTest extends TestCase {
 	/**
 	 * @var \TestApp\Controller\AjaxTestController
 	 */
-	protected $Controller;
+	protected AjaxTestController $Controller;
 
 	/**
 	 * @return void
@@ -49,6 +49,7 @@ class AjaxComponentTest extends TestCase {
 	}
 
 	/**
+	 * @throws \Exception
 	 * @return void
 	 */
 	public function testDefaults() {
@@ -96,6 +97,7 @@ class AjaxComponentTest extends TestCase {
 	}
 
 	/**
+	 * @throws \Exception
 	 * @return void
 	 */
 	public function testAutoDetectOnFalse() {
@@ -111,6 +113,7 @@ class AjaxComponentTest extends TestCase {
 	}
 
 	/**
+	 * @throws \Exception
 	 * @return void
 	 */
 	public function testActionsInvalid() {
@@ -127,6 +130,7 @@ class AjaxComponentTest extends TestCase {
 	}
 
 	/**
+	 * @throws \Exception
 	 * @return void
 	 */
 	public function testActions() {
@@ -143,6 +147,7 @@ class AjaxComponentTest extends TestCase {
 	}
 
 	/**
+	 * @throws \Exception
 	 * @return void
 	 */
 	public function testAutoDetectOnFalseViaConfig() {
@@ -159,6 +164,7 @@ class AjaxComponentTest extends TestCase {
 	}
 
 	/**
+	 * @throws \Exception
 	 * @return void
 	 */
 	public function testSetVars() {

--- a/tests/TestCase/Controller/Component/AjaxComponentTest.php
+++ b/tests/TestCase/Controller/Component/AjaxComponentTest.php
@@ -170,12 +170,12 @@ class AjaxComponentTest extends TestCase {
 
 		$content = ['id' => 1, 'title' => 'title'];
 		$this->Controller->set(compact('content'));
-		$this->Controller->set('_serialize', ['content']);
+		$this->Controller->set('serialize', ['content']);
 
 		$this->Controller->components()->load('Ajax.Ajax');
 		$this->assertNotEmpty($this->Controller->viewBuilder()->getVars());
-		$this->assertNotEmpty($this->Controller->viewBuilder()->getVar('_serialize'));
-		$this->assertEquals('content', $this->Controller->viewBuilder()->getVar('_serialize')[0]);
+		$this->assertNotEmpty($this->Controller->viewBuilder()->getVar('serialize'));
+		$this->assertEquals('content', $this->Controller->viewBuilder()->getVar('serialize')[0]);
 	}
 
 	/**
@@ -189,7 +189,7 @@ class AjaxComponentTest extends TestCase {
 
 		$content = ['id' => 1, 'title' => 'title'];
 		$this->Controller->set(compact('content'));
-		$this->Controller->set('_serialize', ['content']);
+		$this->Controller->set('serialize', ['content']);
 
 		// Let's try a permanent redirect
 		$this->Controller->redirect('/', 301);
@@ -211,8 +211,8 @@ class AjaxComponentTest extends TestCase {
 		$this->assertArrayHasKey('_message', $this->Controller->viewBuilder()->getVars());
 
 		$this->assertNotEmpty($this->Controller->viewBuilder()->getVars());
-		$this->assertNotEmpty($this->Controller->viewBuilder()->getVar('_serialize'));
-		$this->assertTrue(in_array('content', $this->Controller->viewBuilder()->getVar('_serialize')));
+		$this->assertNotEmpty($this->Controller->viewBuilder()->getVar('serialize'));
+		$this->assertTrue(in_array('content', $this->Controller->viewBuilder()->getVar('serialize')));
 	}
 
 }

--- a/tests/TestCase/View/AjaxViewTest.php
+++ b/tests/TestCase/View/AjaxViewTest.php
@@ -24,7 +24,7 @@ class AjaxViewTest extends TestCase {
 	/**
 	 * @var \Ajax\View\AjaxView
 	 */
-	protected $Ajax;
+	protected AjaxView $Ajax;
 
 	/**
 	 * @return void

--- a/tests/TestCase/View/AjaxViewTest.php
+++ b/tests/TestCase/View/AjaxViewTest.php
@@ -48,7 +48,7 @@ class AjaxViewTest extends TestCase {
 			['title' => 'Title Two', 'link' => 'http://example.org/two', 'author' => 'two@example.org', 'description' => 'Content two'],
 		];
 		$View = new AjaxView($Request, $Response);
-		$View->set(['items' => $items, '_serialize' => ['items']]);
+		$View->set(['items' => $items, 'serialize' => ['items']]);
 		$result = $View->render('');
 
 		$response = $View->getResponse();
@@ -69,7 +69,7 @@ class AjaxViewTest extends TestCase {
 			['title' => 'Title Two', 'link' => 'http://example.org/two', 'author' => 'two@example.org', 'description' => 'Content two'],
 		];
 		$View = new AjaxView($Request, $Response);
-		$View->set(['items' => $items, '_serialize' => 'items']);
+		$View->set(['items' => $items, 'serialize' => 'items']);
 		$View->setTemplatePath('Items');
 		$result = $View->render('index');
 
@@ -81,7 +81,7 @@ class AjaxViewTest extends TestCase {
 	}
 
 	/**
-	 * Test the case where the _serialize viewVar is set to true signaling that all viewVars
+	 * Test the case where the `serialize` viewVar is set to true signaling that all viewVars
 	 *   should be serialized.
 	 *
 	 * @return void
@@ -95,7 +95,7 @@ class AjaxViewTest extends TestCase {
 		];
 		$multiple = 'items';
 		$View = new AjaxView($Request, $Response);
-		$View->set(['items' => $items, 'multiple' => $multiple, '_serialize' => true]);
+		$View->set(['items' => $items, 'multiple' => $multiple, 'serialize' => true]);
 		$result = $View->render('');
 
 		$response = $View->getResponse();
@@ -116,7 +116,7 @@ class AjaxViewTest extends TestCase {
 			['title' => 'Title Two', 'link' => 'http://example.org/two', 'author' => 'two@example.org', 'description' => 'Content two'],
 		];
 		$View = new AjaxView($Request, $Response);
-		$View->set(['error' => 'Some message', 'items' => $items, '_serialize' => ['error', 'items']]);
+		$View->set(['error' => 'Some message', 'items' => $items, 'serialize' => ['error', 'items']]);
 		$View->setTemplatePath('Items');
 		$result = $View->render('index');
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,7 +3,7 @@ require dirname(__DIR__) . '/vendor/cakephp/cakephp/src/functions.php';
 require dirname(__DIR__) . '/vendor/autoload.php';
 
 if (!defined('WINDOWS')) {
-	if (DS == '\\' || substr(PHP_OS, 0, 3) === 'WIN') {
+	if (DS == '\\' || str_starts_with(PHP_OS, 'WIN')) {
 		define('WINDOWS', true);
 	} else {
 		define('WINDOWS', false);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,12 @@
 <?php
+
+use Cake\Cache\Cache;
+use Cake\Core\Configure;
+use Cake\Datasource\ConnectionManager;
+use Cake\TestSuite\Fixture\SchemaLoader;
+use Shim\Filesystem\Folder;
+use TestApp\View\AppView;
+
 require dirname(__DIR__) . '/vendor/cakephp/cakephp/src/functions.php';
 require dirname(__DIR__) . '/vendor/autoload.php';
 
@@ -25,15 +33,15 @@ define('CONFIG', dirname(__FILE__) . DS . 'config' . DS);
 
 ini_set('intl.default_locale', 'de-DE');
 
-Cake\Core\Configure::write('App', [
+Configure::write('App', [
 	'namespace' => 'App',
 	'encoding' => 'UTF-8',
 ]);
-Cake\Core\Configure::write('debug', true);
+Configure::write('debug', true);
 
 mb_internal_encoding('UTF-8');
 
-$Tmp = new Shim\Filesystem\Folder(TMP);
+$Tmp = new Folder(TMP);
 $Tmp->create(TMP . 'cache/models', 0770);
 $Tmp->create(TMP . 'cache/persistent', 0770);
 $Tmp->create(TMP . 'cache/views', 0770);
@@ -59,15 +67,15 @@ $cache = [
 	],
 ];
 
-Cake\Cache\Cache::setConfig($cache);
+Cache::setConfig($cache);
 
-Cake\Core\Configure::write('App.paths', [
+Configure::write('App.paths', [
 		'templates' => __DIR__ . DS . 'TestApp' . DS . 'templates' . DS,
 ]);
 
 //Cake\Core\Plugin::load('Ajax', ['path' => ROOT . DS, 'bootstrap' => true]);
 
-class_alias(TestApp\View\AppView::class, 'App\View\AppView');
+class_alias(AppView::class, 'App\View\AppView');
 
 // Ensure default test connection is defined
 if (!getenv('db_class')) {
@@ -75,7 +83,7 @@ if (!getenv('db_class')) {
 	putenv('db_dsn=sqlite::memory:');
 }
 
-Cake\Datasource\ConnectionManager::setConfig('test', [
+ConnectionManager::setConfig('test', [
 	'className' => 'Cake\Database\Connection',
 	'driver' => getenv('db_class') ?: null,
 	'dsn' => getenv('db_dsn') ?: null,
@@ -85,6 +93,6 @@ Cake\Datasource\ConnectionManager::setConfig('test', [
 ]);
 
 if (env('FIXTURE_SCHEMA_METADATA')) {
-	$loader = new Cake\TestSuite\Fixture\SchemaLoader();
+	$loader = new SchemaLoader();
 	$loader->loadInternalFile(env('FIXTURE_SCHEMA_METADATA'));
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,5 @@
 <?php
-require dirname(__DIR__) . '/vendor/cakephp/cakephp/src/basics.php';
+require dirname(__DIR__) . '/vendor/cakephp/cakephp/src/functions.php';
 require dirname(__DIR__) . '/vendor/autoload.php';
 
 if (!defined('WINDOWS')) {

--- a/tests/config/routes.php
+++ b/tests/config/routes.php
@@ -2,9 +2,12 @@
 
 namespace Ajax\Test\App\Config;
 
-use Cake\Routing\Router;
+use Cake\Routing\RouteBuilder;
 
-Router::scope('/', function($routes) {
+/**
+ * @var \Cake\Routing\RouteBuilder $routes
+ */
+$routes->scope('/', function (RouteBuilder $routes) {
 	$routes->connect('/:controller', ['action' => 'index'], ['routeClass' => 'DashedRoute']);
 	$routes->connect('/:controller/:action/*', [], ['routeClass' => 'DashedRoute']);
 });


### PR DESCRIPTION
This PR:

- updates the `viewVar` key used to serialize variables
- updates the Contribution documentation
- updates the `tests/bootstrap.php`'s `require()` that imports CakePHP's global functions with the new path for CakePHP 5

Unfortunately the tests are still not starting due to some incompatibilty between `Cake\TestSuite\TestCase::expectDeprecationMessageMatches(string $regex, Closure $callable):
 void` and `PHPUnit\Framework\TestCase::expectDeprecationMessageMatches(string $regularExpression): void`
I will try to work on that when I find some time!