### PR TITLE
Add strict_types declarations and tighten test assertions

### DIFF
--- a/src/AjaxPlugin.php
+++ b/src/AjaxPlugin.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Ajax;
 

--- a/src/Controller/Component/AjaxComponent.php
+++ b/src/Controller/Component/AjaxComponent.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Ajax\Controller\Component;
 

--- a/src/View/AjaxView.php
+++ b/src/View/AjaxView.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Ajax\View;
 
@@ -74,7 +75,7 @@ class AjaxView extends AppView {
 			$this->templatePath = str_replace(DS . 'ajax', '', $this->templatePath);
 		}
 
-		if (isset($response)) {
+		if ($response !== null) {
 			$response = $response->withType('json');
 			$this->response = $response;
 		}

--- a/src/View/JsonEncoder.php
+++ b/src/View/JsonEncoder.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Ajax\View;
 

--- a/tests/TestCase/Controller/Component/AjaxComponentTest.php
+++ b/tests/TestCase/Controller/Component/AjaxComponentTest.php
@@ -93,7 +93,7 @@ class AjaxComponentTest extends TestCase {
 			'url' => Router::url('/', true),
 			'status' => 302,
 		];
-		$this->assertEquals($expected, $this->Controller->viewBuilder()->getVar('_redirect'));
+		$this->assertSame($expected, $this->Controller->viewBuilder()->getVar('_redirect'));
 	}
 
 	/**
@@ -210,7 +210,7 @@ class AjaxComponentTest extends TestCase {
 			'url' => Router::url('/', true),
 			'status' => 301,
 		];
-		$this->assertEquals($expected, $this->Controller->viewBuilder()->getVar('_redirect'));
+		$this->assertSame($expected, $this->Controller->viewBuilder()->getVar('_redirect'));
 
 		$this->Controller->set(['_message' => 'test']);
 		$this->Controller->redirect('/');


### PR DESCRIPTION
## Summary

- Add ``declare(strict_types=1);`` to all four ``src/`` files (``AjaxPlugin``, ``AjaxView``, ``JsonEncoder``, ``AjaxComponent``). Aligns the runtime type contract with the existing level-8 PHPStan posture so coercion can't bypass static analysis assumptions.
- Replace the ``isset(\$response)`` null-cloak in ``AjaxView::__construct`` with an explicit ``!== null`` check — ``\$response`` is a typed-nullable parameter, so it is always defined; ``isset`` here was a null check disguised as a definedness check.
- Convert the two redirect-payload assertions in ``AjaxComponentTest`` (status codes 302 and 301) from ``assertEquals`` to ``assertSame``. ``Response::withStatus()`` accepts both ``int`` and ``string`` forms, so ``assertSame`` catches accidental type drift on the serialized ``status`` value.

All four blocking gates pass locally: phpunit (13 tests / 31 assertions), phpstan (no errors), phpcs ``src/`` clean.