### PR TITLE
Add enable()/disable() and auto-resolve flashKey from FlashComponent

### DIFF
--- a/src/Controller/Component/AjaxComponent.php
+++ b/src/Controller/Component/AjaxComponent.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 namespace Ajax\Controller\Component;
 
 use Cake\Controller\Component;
+use Cake\Controller\Component\FlashComponent;
 use Cake\Controller\ComponentRegistry;
 use Cake\Core\Configure;
 use Cake\Event\EventInterface;
 use Cake\Http\Response;
 use Cake\Routing\Router;
+use Closure;
 
 /**
  * Ajax Component to respond to AJAX requests.
@@ -30,13 +32,21 @@ class AjaxComponent extends Component {
 	public bool $respondAsAjax = false;
 
 	/**
+	 * Force-state set via enable()/disable(). When non-null, takes precedence over autoDetect.
+	 *
+	 * @var bool|null
+	 */
+	protected ?bool $forced = null;
+
+	/**
 	 * @var array<string, mixed>
 	 */
 	protected array $_defaultConfig = [
 		'viewClass' => 'Ajax.Ajax',
 		'autoDetect' => true,
 		'resolveRedirect' => true,
-		'flashKey' => 'Flash.flash',
+		'flashKey' => null,
+		'flashConsumer' => null,
 		'actions' => [],
 	];
 
@@ -55,10 +65,38 @@ class AjaxComponent extends Component {
 	 * @return void
 	 */
 	public function initialize(array $config): void {
+		if ($this->forced !== null) {
+			$this->respondAsAjax = $this->forced;
+
+			return;
+		}
 		if (!$this->_config['autoDetect'] || !$this->_isActionEnabled()) {
 			return;
 		}
 		$this->respondAsAjax = $this->getController()->getRequest()->is('ajax');
+	}
+
+	/**
+	 * Force AJAX response handling on for the rest of the request, regardless of autoDetect / X-Requested-With.
+	 *
+	 * Useful from `beforeFilter()` or controller actions when responding to non-XHR clients (fetch without
+	 * X-Requested-With, integration tests, internal sub-requests).
+	 *
+	 * @return void
+	 */
+	public function enable(): void {
+		$this->forced = true;
+		$this->respondAsAjax = true;
+	}
+
+	/**
+	 * Force AJAX response handling off, regardless of autoDetect.
+	 *
+	 * @return void
+	 */
+	public function disable(): void {
+		$this->forced = false;
+		$this->respondAsAjax = false;
 	}
 
 	/**
@@ -82,10 +120,12 @@ class AjaxComponent extends Component {
 	protected function _respondAsAjax(): void {
 		$this->getController()->viewBuilder()->setClassName($this->_config['viewClass']);
 
-		// Set flash messages to the view
-		if ($this->_config['flashKey']) {
-			$message = $this->getController()->getRequest()->getSession()->consume($this->_config['flashKey']);
-			$this->getController()->set('_message', $message);
+		// Set flash messages to the view. Skipped when flashKey is explicitly false.
+		if ($this->_config['flashKey'] !== false) {
+			$message = $this->_consumeFlash();
+			if ($message !== null) {
+				$this->getController()->set('_message', $message);
+			}
 		}
 
 		// If `serialize` is true, *all* viewVars will be serialized; no need to add _message.
@@ -137,6 +177,49 @@ class AjaxComponent extends Component {
 		// Further changes will be required here when the change to immutable response objects is completed
 		$response = $this->getController()->render();
 		$event->setResult($response);
+	}
+
+	/**
+	 * Resolves the configured flash session key and consumes its contents.
+	 *
+	 * Resolution order:
+	 *  - If `flashConsumer` is a callable, delegate entirely (it returns whatever shape it likes).
+	 *  - If `flashKey` is a non-empty string, use it verbatim (BC with the previous `'Flash.flash'` default).
+	 *  - Otherwise resolve from the loaded FlashComponent's `key` config (defaults to `flash`),
+	 *    yielding `Flash.<key>` — so an app that reconfigured FlashComponent picks up automatically.
+	 *
+	 * @return mixed Returns null when no flash data is present.
+	 */
+	protected function _consumeFlash(): mixed {
+		$consumer = $this->_config['flashConsumer'];
+		if ($consumer instanceof Closure || (is_object($consumer) && method_exists($consumer, '__invoke')) || (is_string($consumer) && function_exists($consumer))) {
+			return $consumer($this->getController()->getRequest(), $this->_resolveFlashKey());
+		}
+
+		$key = $this->_resolveFlashKey();
+
+		return $this->getController()->getRequest()->getSession()->consume($key);
+	}
+
+	/**
+	 * @return string Session key to consume, e.g. `Flash.flash`.
+	 */
+	protected function _resolveFlashKey(): string {
+		$configured = $this->_config['flashKey'];
+		if (is_string($configured) && $configured !== '') {
+			return $configured;
+		}
+
+		$controller = $this->getController();
+		if ($controller->components()->has('Flash')) {
+			$flash = $controller->components()->get('Flash');
+			assert($flash instanceof FlashComponent);
+			$flashKey = (string)$flash->getConfig('key', 'flash');
+
+			return 'Flash.' . $flashKey;
+		}
+
+		return 'Flash.flash';
 	}
 
 	/**

--- a/tests/TestCase/Controller/Component/AjaxComponentTest.php
+++ b/tests/TestCase/Controller/Component/AjaxComponentTest.php
@@ -8,6 +8,7 @@ use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
+use Cake\Utility\Hash;
 use TestApp\Controller\AjaxTestController;
 
 class AjaxComponentTest extends TestCase {
@@ -219,6 +220,177 @@ class AjaxComponentTest extends TestCase {
 		$this->assertNotEmpty($this->Controller->viewBuilder()->getVars());
 		$this->assertNotEmpty($this->Controller->viewBuilder()->getVar('serialize'));
 		$this->assertTrue(in_array('content', $this->Controller->viewBuilder()->getVar('serialize')));
+	}
+
+	/**
+	 * enable() must force AJAX handling on for non-XHR requests too.
+	 *
+	 * @return void
+	 */
+	public function testEnableForcesAjaxOnNonXhr() {
+		$this->Controller = new AjaxTestController(new ServerRequest(), new Response());
+		$this->Controller->startupProcess();
+
+		$this->assertFalse($this->Controller->components()->Ajax->respondAsAjax);
+
+		$this->Controller->components()->Ajax->enable();
+		$this->assertTrue($this->Controller->components()->Ajax->respondAsAjax);
+
+		$event = new Event('Controller.beforeRender');
+		$this->Controller->components()->Ajax->beforeRender($event);
+
+		$this->assertSame('Ajax.Ajax', $this->Controller->viewBuilder()->getClassName());
+	}
+
+	/**
+	 * disable() must force AJAX handling off even when X-Requested-With is set.
+	 *
+	 * @return void
+	 */
+	public function testDisableForcesAjaxOffOnXhr() {
+		$_SERVER['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest';
+
+		$this->Controller = new AjaxTestController(new ServerRequest(), new Response());
+		$this->Controller->startupProcess();
+
+		$this->assertTrue($this->Controller->components()->Ajax->respondAsAjax);
+
+		$this->Controller->components()->Ajax->disable();
+		$this->assertFalse($this->Controller->components()->Ajax->respondAsAjax);
+
+		// beforeRender must short-circuit and leave the view class alone
+		$event = new Event('Controller.beforeRender');
+		$this->Controller->components()->Ajax->beforeRender($event);
+		$this->assertNotSame('Ajax.Ajax', $this->Controller->viewBuilder()->getClassName());
+	}
+
+	/**
+	 * Calling enable() before initialize() must survive autoDetect overwriting respondAsAjax.
+	 *
+	 * @return void
+	 */
+	public function testEnableBeforeInitializeWins() {
+		$this->Controller = new AjaxTestController(new ServerRequest(), new Response());
+
+		$this->Controller->components()->unload('Ajax');
+		$this->Controller->components()->load('Ajax.Ajax');
+		$this->Controller->components()->Ajax->enable();
+
+		// Re-run initialize to simulate the lifecycle (defensive: forced should still win)
+		$this->Controller->components()->Ajax->initialize([]);
+
+		$this->assertTrue($this->Controller->components()->Ajax->respondAsAjax);
+	}
+
+	/**
+	 * flashKey defaults must auto-resolve from a loaded FlashComponent's `key` config.
+	 *
+	 * @return void
+	 */
+	public function testFlashKeyAutoResolvesFromFlashComponent() {
+		$_SERVER['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest';
+
+		$this->Controller = new AjaxTestController(new ServerRequest(), new Response());
+		$this->Controller->components()->load('Flash', ['key' => 'myStack']);
+
+		$this->Controller->getRequest()->getSession()->write('Flash.myStack', [
+			['message' => 'Saved', 'key' => 'myStack', 'element' => 'flash/success', 'params' => []],
+		]);
+
+		$event = new Event('Controller.beforeRender');
+		$this->Controller->components()->Ajax->beforeRender($event);
+
+		$message = $this->Controller->viewBuilder()->getVar('_message');
+		$this->assertIsArray($message);
+		$this->assertSame('Saved', Hash::get($message, '0.message'));
+
+		// Default behavior is destructive consume.
+		$this->assertNull($this->Controller->getRequest()->getSession()->read('Flash.myStack'));
+	}
+
+	/**
+	 * flashKey explicitly set to false suppresses _message entirely (lets FlashHelper render later).
+	 *
+	 * @return void
+	 */
+	public function testFlashKeyFalseSuppressesMessage() {
+		$_SERVER['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest';
+		Configure::write('Ajax.flashKey', false);
+
+		$this->Controller = new AjaxTestController(new ServerRequest(), new Response());
+		$this->Controller->components()->load('Flash');
+		$this->Controller->components()->Flash->success('Hello');
+
+		$event = new Event('Controller.beforeRender');
+		$this->Controller->components()->Ajax->beforeRender($event);
+
+		$this->assertNull($this->Controller->viewBuilder()->getVar('_message'));
+		// And the flash is left intact for the helper.
+		$this->assertNotNull($this->Controller->getRequest()->getSession()->read('Flash.flash'));
+	}
+
+	/**
+	 * flashConsumer callable can implement non-destructive read or shape transformation.
+	 *
+	 * @return void
+	 */
+	public function testFlashConsumerCallable() {
+		$_SERVER['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest';
+		Configure::write('Ajax.flashConsumer', function (ServerRequest $req, string $key): ?string {
+			$messages = $req->getSession()->consume($key);
+			if (!is_array($messages) || !$messages) {
+				return null;
+			}
+
+			return (string)($messages[0]['message'] ?? '');
+		});
+
+		$this->Controller = new AjaxTestController(new ServerRequest(), new Response());
+		$this->Controller->components()->load('Flash');
+		$this->Controller->components()->Flash->error('Boom');
+
+		$event = new Event('Controller.beforeRender');
+		$this->Controller->components()->Ajax->beforeRender($event);
+
+		// Consumer normalized the array stack down to a single string.
+		$this->assertSame('Boom', $this->Controller->viewBuilder()->getVar('_message'));
+	}
+
+	/**
+	 * No FlashComponent loaded and no flash data in session: _message must not be set.
+	 *
+	 * @return void
+	 */
+	public function testNoFlashDataDoesNotSetMessage() {
+		$_SERVER['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest';
+
+		$this->Controller = new AjaxTestController(new ServerRequest(), new Response());
+
+		$event = new Event('Controller.beforeRender');
+		$this->Controller->components()->Ajax->beforeRender($event);
+
+		$this->assertSame('Ajax.Ajax', $this->Controller->viewBuilder()->getClassName());
+		$this->assertNull($this->Controller->viewBuilder()->getVar('_message'));
+	}
+
+	/**
+	 * BC: legacy explicit flashKey string still wins over the auto-resolve path.
+	 *
+	 * @return void
+	 */
+	public function testLegacyExplicitFlashKey() {
+		$_SERVER['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest';
+		Configure::write('Ajax.flashKey', 'Flash.legacy');
+
+		$this->Controller = new AjaxTestController(new ServerRequest(), new Response());
+		// FlashComponent's own key is `flash`, but the explicit override wins.
+		$this->Controller->components()->load('Flash');
+		$this->Controller->getRequest()->getSession()->write('Flash.legacy', ['legacy data']);
+
+		$event = new Event('Controller.beforeRender');
+		$this->Controller->components()->Ajax->beforeRender($event);
+
+		$this->assertSame(['legacy data'], $this->Controller->viewBuilder()->getVar('_message'));
 	}
 
 }


### PR DESCRIPTION
## Summary

- New `enable()` / `disable()` methods on `AjaxComponent` plus a `protected ?bool $forced` flag so non-XHR flows (fetch without `X-Requested-With`, integration tests, internal sub-requests) can force AJAX response handling on or off without poking the public `$respondAsAjax` property. `forced` takes precedence over `autoDetect`.
- `flashKey` default changed from the hard-coded `'Flash.flash'` to `null`, which now auto-resolves from the loaded `FlashComponent`'s `key` config (defaults to `'flash'` when no FlashComponent is loaded). Apps that reconfigured FlashComponent — e.g. `key => 'myStack'` — pick up the right session key without having to mirror it on this component.
- `flashKey === false` now suppresses the `_message` viewVar entirely and leaves the session intact, so a later `FlashHelper::render()` can still consume the stack.
- New `flashConsumer` callable config lets apps implement a non-destructive peek or transform the raw stack into a different shape (for example, flatten the cakephp-flash array stack into a single string for the JSON envelope).

Backwards compatible:
- An explicit string set via `Configure::write('Ajax.flashKey', 'Flash.legacy')` still wins over the auto-resolve path.
- The destructive consume remains the default when no callable is configured.
- All 13 existing tests continue to pass unchanged.

8 new tests in `AjaxComponentTest` cover the force API (both directions, plus precedence over a re-`initialize()`), the FlashComponent auto-resolve path, the `false` suppression, the `flashConsumer` callable shape, the empty-session branch, and the legacy explicit-string path. phpunit (21/21, 47 assertions), phpstan, and phpcs all pass locally.