### PR TITLE
Add opt-in detectors for modern JSON clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ See the [Sandbox app](https://sandbox.dereuromark.de/sandbox/ajax-examples) for 
 ### Key features
 - Auto-handling via View class mapping and making controller actions available both AJAX and non-AJAX by design.
 - Flash message and redirect (prevention) support.
+- Opt-in detection for modern JSON-oriented clients that do not send `X-Requested-With`.
 
 See [my article](https://www.dereuromark.de/2014/01/09/ajax-and-cakephp/) for details on the history of this view class and plugin code.
 

--- a/docs/Component/Ajax.md
+++ b/docs/Component/Ajax.md
@@ -155,6 +155,28 @@ success: function(response, newValue) {
 ## Configs
 
 - 'autoDetect' => true // Detect AJAX automatically, regardless of the extension
+- 'detectors' => ['ajax'] // Auto-detection strategies: 'ajax', 'acceptJson', 'jsonExtension'
 - 'resolveRedirect' => true // Send redirects to the view, without actually redirecting
 - 'flashKey' => 'Flash.flash' // Set to false to disable
 - 'actions' => [] // Set to an array of actions if you want to only whitelist these specific actions
+
+## Modern clients without X-Requested-With
+
+Classic CakePHP AJAX detection relies on the `X-Requested-With: XMLHttpRequest` header.
+Modern `fetch()` calls often omit that header by default.
+
+If you want the component to auto-switch for JSON-first clients without having to call
+`$this->Ajax->enable()` manually, opt into additional detectors:
+
+```php
+$this->loadComponent('Ajax.Ajax', [
+    'detectors' => ['ajax', 'acceptJson', 'jsonExtension'],
+]);
+```
+
+Available detectors:
+- `ajax`: Legacy XHR detection via `X-Requested-With`.
+- `acceptJson`: Treat requests with `Accept: application/json` or `+json` media types as AJAX.
+- `jsonExtension`: Treat requests using the `.json` extension as AJAX.
+
+The default remains `['ajax']` for backwards compatibility.

--- a/src/Controller/Component/AjaxComponent.php
+++ b/src/Controller/Component/AjaxComponent.php
@@ -44,6 +44,7 @@ class AjaxComponent extends Component {
 	protected array $_defaultConfig = [
 		'viewClass' => 'Ajax.Ajax',
 		'autoDetect' => true,
+		'detectors' => ['ajax'],
 		'resolveRedirect' => true,
 		'flashKey' => null,
 		'flashConsumer' => null,
@@ -73,7 +74,7 @@ class AjaxComponent extends Component {
 		if (!$this->_config['autoDetect'] || !$this->_isActionEnabled()) {
 			return;
 		}
-		$this->respondAsAjax = $this->getController()->getRequest()->is('ajax');
+		$this->respondAsAjax = $this->_shouldRespondAsAjax();
 	}
 
 	/**
@@ -138,6 +139,46 @@ class AjaxComponent extends Component {
 			$serializeKeys = array_merge($serializeKeys, (array)$this->getController()->viewBuilder()->getVar('serialize'));
 		}
 		$this->getController()->set('serialize', $serializeKeys);
+	}
+
+	/**
+	 * @return bool
+	 */
+	protected function _shouldRespondAsAjax(): bool {
+		$request = $this->getController()->getRequest();
+
+		foreach ((array)$this->getConfig('detectors') as $detector) {
+			if ($detector === 'ajax' && $request->is('ajax')) {
+				return true;
+			}
+			if ($detector === 'acceptJson' && $this->_acceptsJson($request->getHeaderLine('Accept'))) {
+				return true;
+			}
+			if ($detector === 'jsonExtension' && $request->getParam('_ext') === 'json') {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * @param string $acceptHeader
+	 * @return bool
+	 */
+	protected function _acceptsJson(string $acceptHeader): bool {
+		if ($acceptHeader === '') {
+			return false;
+		}
+
+		foreach (explode(',', $acceptHeader) as $part) {
+			$mediaType = trim(strtolower(explode(';', $part)[0]));
+			if ($mediaType === 'application/json' || str_ends_with($mediaType, '+json')) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/tests/TestCase/Controller/Component/AjaxComponentTest.php
+++ b/tests/TestCase/Controller/Component/AjaxComponentTest.php
@@ -165,6 +165,65 @@ class AjaxComponentTest extends TestCase {
 	}
 
 	/**
+	 * @return void
+	 */
+	public function testAcceptJsonDoesNotEnableByDefault() {
+		$request = new ServerRequest([
+			'environment' => ['HTTP_ACCEPT' => 'application/json'],
+		]);
+		$this->Controller = new AjaxTestController($request, new Response());
+
+		$this->Controller->startupProcess();
+
+		$this->assertFalse($this->Controller->components()->Ajax->respondAsAjax);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAcceptJsonDetector() {
+		Configure::write('Ajax.detectors', ['ajax', 'acceptJson']);
+		$request = new ServerRequest([
+			'environment' => ['HTTP_ACCEPT' => 'application/json, text/plain;q=0.5'],
+		]);
+		$this->Controller = new AjaxTestController($request, new Response());
+
+		$this->Controller->startupProcess();
+
+		$this->assertTrue($this->Controller->components()->Ajax->respondAsAjax);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testAcceptJsonDetectorWithVendorMediaType() {
+		Configure::write('Ajax.detectors', ['acceptJson']);
+		$request = new ServerRequest([
+			'environment' => ['HTTP_ACCEPT' => 'application/vnd.api+json'],
+		]);
+		$this->Controller = new AjaxTestController($request, new Response());
+
+		$this->Controller->startupProcess();
+
+		$this->assertTrue($this->Controller->components()->Ajax->respondAsAjax);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testJsonExtensionDetector() {
+		Configure::write('Ajax.detectors', ['jsonExtension']);
+		$request = new ServerRequest([
+			'params' => ['_ext' => 'json'],
+		]);
+		$this->Controller = new AjaxTestController($request, new Response());
+
+		$this->Controller->startupProcess();
+
+		$this->assertTrue($this->Controller->components()->Ajax->respondAsAjax);
+	}
+
+	/**
 	 * @throws \Exception
 	 * @return void
 	 */


### PR DESCRIPTION
## Summary
- add opt-in AjaxComponent detectors for modern JSON-oriented clients
- support Accept-based JSON detection and .json extension detection
- document the new detector config and keep the default as legacy XHR-only for BC

## Why
PR #57 added explicit enable()/disable() forcing, which solves manual control well. This follow-up addresses the remaining auto-detection gap for modern clients that use fetch()/API-style requests without sending X-Requested-With.

## Tests
- vendor/bin/phpunit tests/TestCase/Controller/Component/AjaxComponentTest.php tests/TestCase/View/AjaxViewTest.php
- vendor/bin/phpstan analyze