### PR TITLE
Fix flash key resolver assuming core FlashComponent

### DIFF
--- a/src/Controller/Component/AjaxComponent.php
+++ b/src/Controller/Component/AjaxComponent.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace Ajax\Controller\Component;
 
 use Cake\Controller\Component;
-use Cake\Controller\Component\FlashComponent;
 use Cake\Controller\ComponentRegistry;
 use Cake\Core\Configure;
 use Cake\Event\EventInterface;
@@ -254,7 +253,6 @@ class AjaxComponent extends Component {
 		$controller = $this->getController();
 		if ($controller->components()->has('Flash')) {
 			$flash = $controller->components()->get('Flash');
-			assert($flash instanceof FlashComponent);
 			$flashKey = (string)$flash->getConfig('key', 'flash');
 
 			return 'Flash.' . $flashKey;

--- a/tests/TestApp/src/Controller/Component/CustomFlashComponent.php
+++ b/tests/TestApp/src/Controller/Component/CustomFlashComponent.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Controller\Component;
+
+use Cake\Controller\Component;
+
+/**
+ * Stand-in for a non-cake-core Flash component (e.g. dereuromark/cakephp-flash).
+ * Extends Cake\Controller\Component directly — does NOT extend Cake\Controller\Component\FlashComponent.
+ */
+class CustomFlashComponent extends Component {
+
+	/**
+	 * @var array
+	 */
+	protected array $_defaultConfig = [
+		'key' => 'flash',
+	];
+
+}

--- a/tests/TestCase/Controller/Component/AjaxComponentTest.php
+++ b/tests/TestCase/Controller/Component/AjaxComponentTest.php
@@ -433,6 +433,33 @@ class AjaxComponentTest extends TestCase {
 	}
 
 	/**
+	 * Auto-resolve must work with a non-cake-core Flash component (e.g. dereuromark/cakephp-flash),
+	 * which extends `Cake\Controller\Component` directly rather than the core `FlashComponent`.
+	 *
+	 * @return void
+	 */
+	public function testFlashKeyAutoResolvesFromCustomFlashComponent() {
+		$_SERVER['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest';
+
+		$this->Controller = new AjaxTestController(new ServerRequest(), new Response());
+		$this->Controller->components()->load('Flash', [
+			'className' => 'TestApp\Controller\Component\CustomFlashComponent',
+			'key' => 'myStack',
+		]);
+
+		$this->Controller->getRequest()->getSession()->write('Flash.myStack', [
+			['message' => 'Saved', 'key' => 'myStack', 'element' => 'flash/success', 'params' => []],
+		]);
+
+		$event = new Event('Controller.beforeRender');
+		$this->Controller->components()->Ajax->beforeRender($event);
+
+		$message = $this->Controller->viewBuilder()->getVar('_message');
+		$this->assertIsArray($message);
+		$this->assertSame('Saved', Hash::get($message, '0.message'));
+	}
+
+	/**
 	 * BC: legacy explicit flashKey string still wins over the auto-resolve path.
 	 *
 	 * @return void


### PR DESCRIPTION
## Summary

`AjaxComponent::_resolveFlashKey()` asserts the loaded Flash component is a `Cake\Controller\Component\FlashComponent`, but alternative Flash plugins (e.g. `dereuromark/cakephp-flash`) provide their own component under the same `Flash` alias without extending the core class. With `zend.assertions=1` (PHP dev default) and `assert.exception=1`, the assertion throws `AssertionError` and breaks any controller using such a component.

## Fix

The call only depends on `getConfig('key', ...)`, which every `Cake\Controller\Component` subclass provides via `InstanceConfigTrait`. The narrower type guard was redundant — drop the assertion and the now-unused `FlashComponent` import.

## Regression coverage

Added `testFlashKeyAutoResolvesFromCustomFlashComponent` which loads a stand-in component (extends `Cake\Controller\Component` directly, not the core `FlashComponent`) under the `Flash` alias and verifies the resolver still consumes flash data correctly. On master with the assertion in place, this test fails with `AssertionError` whenever `zend.assertions` is enabled.